### PR TITLE
Bumped requests dependency to fix SSLError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ##### Dependencies
-requests==2.2.1
+requests==2.7.0
 
 ##### DEV Dependencies
 cov-core==1.7

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     license='MIT',
     packages=find_packages(exclude='tests'),
     package_data={'README': ['README.md']},
-    install_requires=['requests==2.2.1'],
+    install_requires=['requests==2.7.0'],
     zip_safe=False,
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
About a week ago I wasn't able to connect to Plaid using this client library anymore, I just got the following exception:

```
Traceback (most recent call last):
  File "./get_transactions.py", line 40, in <module>
    response = client.connect_get()
  File "/.../venv/lib/python2.7/site-packages/plaid/client.py", line 50, in inner_func
    return func(self, credentials, *args, **kwargs)
  File "/.../venv/lib/python2.7/site-packages/plaid/client.py", line 25, in inner_func
    return func(self, url, *args, **kwargs)
  File "/.../venv/lib/python2.7/site-packages/plaid/client.py", line 402, in connect_get
    suppress_errors=self.suppress_http_errors
  File "/.../venv/lib/python2.7/site-packages/plaid/requester.py", line 14, in http_request
    response = _base_http_request(url, method, data or {})
  File "/.../venv/lib/python2.7/site-packages/plaid/http.py", line 69, in _inner_http_request
    return req(url, method, data)
  File "/.../venv/lib/python2.7/site-packages/plaid/http.py", line 21, in _requests_http_request
    'User-Agent': 'Plaid Python v{}'.format(__version__)
  File "/.../venv/lib/python2.7/site-packages/requests/api.py", line 88, in post
    return request('post', url, data=data, **kwargs)
  File "/.../venv/lib/python2.7/site-packages/requests/api.py", line 44, in request
    return session.request(method=method, url=url, **kwargs)
  File "/.../venv/lib/python2.7/site-packages/requests/sessions.py", line 383, in request
    resp = self.send(prep, **send_kwargs)
  File "/.../venv/lib/python2.7/site-packages/requests/sessions.py", line 486, in send
    r = adapter.send(request, **kwargs)
  File "/.../venv/lib/python2.7/site-packages/requests/adapters.py", line 385, in send
    raise SSLError(e)
requests.exceptions.SSLError: [Errno bad handshake] [('SSL routines', 'SSL23_GET_SERVER_HELLO', 'sslv3 alert handshake failure')]
```

After upgrading requests to the latest version (2.7.0), everything went back to normal.