### PR TITLE
Fix README typo: flakes8 -> flake8.

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ Open an [issue][5]!
 
 ## Contribute
 
-All pull requests should be linted with flakes8 and tested by running:
+All pull requests should be linted with flake8 and tested by running:
 
 ```console
 $ make test


### PR DESCRIPTION
Just a tiny fix to the readme - fix typo `flakes8` to `flake8`.