### PR TITLE
travis: limit Python versions to 2.7 and 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,7 @@ language: python
 
 python:
   - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-  - "3.5.0b3"
-  - "3.5-dev"
-  - "nightly"
+  - "3.5"
 
 install:
   - "pip install -r requirements.txt"


### PR DESCRIPTION
[Build 96338732][1] failed on Python 3.3. Let's see whether we can get the tests to pass. :)


[1]: https://travis-ci.org/plaid/plaid-python/builds/96338732
