### PR TITLE
added /info and /info/step endpoints

### DIFF
--- a/plaid/client.py
+++ b/plaid/client.py
@@ -104,6 +104,8 @@ class Client(object):
         'connect_step': '/connect/step',
         'categories': '/categories',
         'category': '/categories/{}',
+        'info': '/info',
+        'info_step': '/info/step',
         'info_get': '/info/get',
         'institutions': '/institutions',
         'institution': '/institutions/{}',
@@ -345,6 +347,22 @@ class Client(object):
             )),
             suppress_errors=self.suppress_http_errors
         )
+
+    @inject_url('info')
+    def info(self, url, *args, **kwargs):
+        '''
+        Add an Info user to Plaid.
+        See _add docstring for input annotation
+        '''
+        return self._add(url, *args, **kwargs)
+
+    @inject_url('info_step')
+    def info_step(self, url, *args, **kwargs):
+        '''
+        MFA step associated with initially adding an Info user.
+        See _step docstring for input annotation
+        '''
+        return self._step(url, 'POST', *args, **kwargs)
 
     @store_access_token
     @inject_credentials

--- a/plaid/http.py
+++ b/plaid/http.py
@@ -48,7 +48,7 @@ def _urlfetch_http_request(url, method, data):
         method=method,
         payload=payload,
         headers=headers,
-        deadline=60 # seconds
+        deadline=60  # seconds
     )
 
     # Add consistent interface across requests library and urlfetch

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -123,6 +123,26 @@ def test_connect_step_update():
     assert response.status_code == 200
 
 
+def test_info_no_mfa():
+    client = Client('test_id', 'test_secret')
+    response = client.info('wells', no_mfa_credentials)
+    assert to_json(response)['access_token'] == 'test_wells'
+
+
+def test_info_mfa():
+    client = Client('test_id', 'test_secret')
+    response = client.info('pnc', no_mfa_credentials)
+    assert response.status_code == 201
+    assert to_json(response)['type'] == 'questions'
+
+
+def test_info_step():
+    client = Client('test_id', 'test_secret', access_token='test_pnc')
+    response = client.info_step('pnc', 'tomato')
+    assert response.status_code == 200
+    assert to_json(response)['access_token'] == 'test_pnc'
+
+
 def test_upgrade():
     client = Client('test_id', 'test_secret', access_token='test_bofa')
     response = client.upgrade('info')


### PR DESCRIPTION
Needed these endpoints for an application I'm building so I figured I'd create and share them in Plaid's Python library. I also fixed an error in PEP-8 style that prevented "make test" from running.