### PR TITLE
Fix broken test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ pip-log.txt
 # Unit test / coverage reports
 .coverage
 .tox
+.cache
 nosetests.xml
 
 # Translations

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ python:
   - "3.4"
   - "3.5"
 install:
-  - "pip install -r requirements.txt"
-  - "pip install flake8"
-
-becore_script: "flake8 plaid tests"
-script: nosetests
+  - "make setup"
+becore_script:
+  - "make lint"
+script:
+  - "make test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,7 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
-  - "3.5.0b3"
-  - "3.5-dev"
-  - "nightly"
-
+  - "3.5"
 install:
   - "pip install -r requirements.txt"
   - "pip install flake8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ cov-core==1.7
 coverage==3.7.1
 flake8==2.4.1
 mock==1.0.1
-py==1.4.20
-pytest==2.5.2
+py==1.4.32
+pytest==2.9.2
 pytest-cov==1.6

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Environment :: Web Environment",
     ]

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -311,7 +311,7 @@ def test_unauthorizedError_bad_password():
 def test_ResourceNotFound_connect():
     client = Client('test_id', 'test_secret')
     with pytest.raises(ResourceNotFoundError):
-        client.connect('pnc', no_mfa_credentials)
+        client.connect('notpnc', no_mfa_credentials)
 
 
 def test_ResourceNotFound_categories():


### PR DESCRIPTION
The test suite would not run under python 3.5 due to pytest incompatibilities. Additionally, the travis config for this project no longer appears to be valid which this pull also corrects.

Once I had the test suite running, I discovered a bad test which was failing. I've corrected that test so that it verifies the expected behavior and passes.