### PR TITLE
requests >= 2.7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     license='MIT',
     packages=find_packages(exclude='tests'),
     package_data={'README': ['README.md']},
-    install_requires=['requests==2.7.0'],
+    install_requires=['requests>=2.7.0'],
     zip_safe=False,
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
Allow the use of plaid-python in projects that use requests>=2.7.0.