### PR TITLE
Avoid having generated python docs processed by Jekyll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ venv
 .tox/*
 
 docs/.*
+!docs/.nojekyll
 docs/objects.inv


### PR DESCRIPTION
This should fix the issue where static files weren't being loaded for the generated docs.

Per https://help.github.com/articles/files-that-start-with-an-underscore-are-missing/.