### PR TITLE
Added logic for request timeouts

### DIFF
--- a/plaid/client.py
+++ b/plaid/client.py
@@ -13,7 +13,7 @@ from plaid.api import (
     Sandbox,
     Transactions,
 )
-from plaid.requester import post_request
+from plaid.requester import DEFAULT_TIMEOUT, post_request
 from plaid.utils import urljoin
 
 
@@ -32,7 +32,8 @@ class Client(object):
                  secret,
                  public_key,
                  environment,
-                 suppress_warnings=False):
+                 suppress_warnings=False,
+                 timeout=DEFAULT_TIMEOUT):
         '''
         Initialize a client with credentials.
 
@@ -42,12 +43,15 @@ class Client(object):
         :arg    str     environment:        One of ``sandbox``,
                                             ``development``, or ``production``.
         :arg    bool    suppress_warnings:  Suppress Plaid warnings.
+        :arg    int     timeout:            Timeout for API requests.
+
         '''
         self.client_id = client_id
         self.secret = secret
         self.public_key = public_key
         self.environment = environment
         self.suppress_warnings = suppress_warnings
+        self.timeout = timeout
 
         if self.environment == 'development' and not self.suppress_warnings:
             warnings.warn('''
@@ -93,5 +97,5 @@ class Client(object):
     def _post(self, path, data):
         return post_request(
             urljoin('https://' + self.environment + '.plaid.com', path),
-            data=data,
+            data=data, timeout=self.timeout
         )

--- a/plaid/client.py
+++ b/plaid/client.py
@@ -97,5 +97,6 @@ class Client(object):
     def _post(self, path, data):
         return post_request(
             urljoin('https://' + self.environment + '.plaid.com', path),
-            data=data, timeout=self.timeout
+            data=data,
+            timeout=self.timeout
         )

--- a/plaid/requester.py
+++ b/plaid/requester.py
@@ -8,7 +8,7 @@ from plaid.version import __version__
 
 
 ALLOWED_METHODS = {'post'}
-DEFAULT_TIMEOUT = 600 # 10 minutes
+DEFAULT_TIMEOUT = 600  # 10 minutes
 
 
 def _requests_http_request(url, method, data, timeout=DEFAULT_TIMEOUT):

--- a/plaid/requester.py
+++ b/plaid/requester.py
@@ -8,10 +8,10 @@ from plaid.version import __version__
 
 
 ALLOWED_METHODS = {'post'}
-TIMEOUT = 600  # 10 minutes
+DEFAULT_TIMEOUT = 600 # 10 minutes
 
 
-def _requests_http_request(url, method, data):
+def _requests_http_request(url, method, data, timeout=DEFAULT_TIMEOUT):
     normalized_method = method.lower()
     if normalized_method in ALLOWED_METHODS:
         return getattr(requests, normalized_method)(
@@ -20,7 +20,7 @@ def _requests_http_request(url, method, data):
             headers={
                 'User-Agent': 'Plaid Python v{}'.format(__version__),
             },
-            timeout=TIMEOUT,
+            timeout=timeout,
         )
     else:
         raise Exception(
@@ -28,8 +28,8 @@ def _requests_http_request(url, method, data):
         )
 
 
-def http_request(url, method=None, data=None):
-    response = _requests_http_request(url, method, data or {})
+def http_request(url, method=None, data=None, timeout=DEFAULT_TIMEOUT):
+    response = _requests_http_request(url, method, data or {}, timeout)
     response_body = json.loads(response.text)
     if response_body.get('error_type'):
         raise PlaidError.from_response(response_body)


### PR DESCRIPTION
## Motivation

Many of the newer institutions (especially for Auth and Identity) take several minutes to receive a response.  It would be ideal for anyone consuming this API to be able to set a timeout as they would for any other request.  

This PR adds a `timeout` argument to the Client() object; all API requests are then limited to the specified timeout, else a `ReadTimeoutError` is raised.