### PR TITLE
Correct RATE_LIMIT_EXCEEDED error type

### DIFF
--- a/plaid/errors.py
+++ b/plaid/errors.py
@@ -64,7 +64,7 @@ class ItemError(PlaidError):
 PLAID_ERROR_TYPE_MAP = {
     'INVALID_REQUEST': InvalidRequestError,
     'INVALID_INPUT': InvalidInputError,
-    'RATE_LIMIT_EXCEEDED_ERROR': RateLimitExceededError,
+    'RATE_LIMIT_EXCEEDED': RateLimitExceededError,
     'API_ERROR': APIError,
     'ITEM_ERROR': ItemError,
 }


### PR DESCRIPTION
As per https://plaid.com/docs/api/#errors, the error type for rate limit errors is `RATE_LIMIT_EXCEEDED`.