### PR TITLE
Fix docs hosting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ venv
 .coverage
 .tox/*
 
-docs/.*
-!docs/.nojekyll
+docs/.buildinfo
+docs/.doctrees
 docs/objects.inv
+
+dist


### PR DESCRIPTION
Since the static resources folder `docs/_static` starts with an `_`, we want to bypass jekyll processing for hosting: https://github.com/blog/572-bypassing-jekyll-on-github-pages.