### PR TITLE
Add support for Dwolla processor token

### DIFF
--- a/plaid/api/processor.py
+++ b/plaid/api/processor.py
@@ -9,10 +9,24 @@ class Processor(API):
         Create a Stripe bank_account token for a given account ID
         (`HTTP docs <https://plaid.com/docs/link/stripe>`__)
 
-        :param  str     public_token:
+        :param  str     access_token:
         :param  str     account_id:
         '''
         return self.client.post('/processor/stripe/bank_account_token/create',
+                                {
+                                    'access_token': access_token,
+                                    'account_id': account_id,
+                                })
+
+    def dwollaBankAccountTokenCreate(self, access_token, account_id):
+        '''
+        Create a Dwolla processor token for a given account ID
+        (`HTTP docs <https://plaid.com/docs/link/dwolla>`__)
+
+        :param  str     access_token:
+        :param  str     account_id:
+        '''
+        return self.client.post('/processor/dwolla/processor_token/create',
                                 {
                                     'access_token': access_token,
                                     'account_id': account_id,

--- a/tests/integration/test_processor.py
+++ b/tests/integration/test_processor.py
@@ -12,10 +12,20 @@ from tests.integration.util import (
     create_client
 )
 
-def test_processor_token():
+
+def test_stripe_processor_token():
     client = create_client()
     # Just test the failure case - behavior here depends on the API keys used
     with pytest.raises(InvalidRequestError) as e:
         client.Processor.stripeBankAccountTokenCreate(
+            'fakeAccessToken', 'fakeAccountId')
+        assert e.code == 'INVALID_INPUT'
+
+
+def test_dwolla_processor_token():
+    client = create_client()
+    # Just test the failure case - behavior here depends on the API keys used
+    with pytest.raises(InvalidRequestError) as e:
+        client.Processor.dwollaBankAccountTokenCreate(
             'fakeAccessToken', 'fakeAccountId')
         assert e.code == 'INVALID_INPUT'


### PR DESCRIPTION
Adding support for Dwolla processor token. Mimicking code currently used for Stripe