### PR TITLE
Removed occurences of mutable kwargs

### DIFF
--- a/plaid/api/accounts.py
+++ b/plaid/api/accounts.py
@@ -6,7 +6,7 @@ class Balance(API):
 
     def get(self,
             access_token,
-            _options={},
+            _options=None,
             account_ids=None):
         '''
         Retrieve real-time balance information for accounts.
@@ -15,8 +15,7 @@ class Balance(API):
         :param  [str]   account_ids:    A list of account_ids to retrieve for
                                         the item. Optional.
         '''
-        options = {}
-        options.update(_options)
+        options = _options or {}
         if account_ids is not None:
             options['account_ids'] = account_ids
 
@@ -41,7 +40,7 @@ class Accounts(API):
 
     def get(self,
             access_token,
-            _options={},
+            _options=None,
             account_ids=None):
         '''
         Retrieve high-level account information for an Item.
@@ -50,8 +49,7 @@ class Accounts(API):
         :param  [str]   account_ids:    A list of account_ids to retrieve for
                                         the item. Optional.
         '''
-        options = {}
-        options.update(_options)
+        options = _options or {}
         if account_ids is not None:
             options['account_ids'] = account_ids
 

--- a/plaid/api/assets.py
+++ b/plaid/api/assets.py
@@ -12,7 +12,7 @@ class AssetReport(API):
     def create(self,
                access_tokens,
                days_requested,
-               options={}):
+               options=None):
         '''
         Create an asset report.
 
@@ -25,6 +25,7 @@ class AssetReport(API):
                                         information on the options object, see
                                         the documentation site listed above.
         '''
+        options = options or {}
 
         return self.client.post('/asset_report/create', {
             'access_tokens': access_tokens,
@@ -44,7 +45,6 @@ class AssetReport(API):
                                                 exclude from the new Asset
                                                 Report.
         '''
-
         return self.client.post('/asset_report/filter', {
             'asset_report_token': asset_report_token,
             'account_ids_to_exclude': account_ids_to_exclude,
@@ -53,7 +53,7 @@ class AssetReport(API):
     def refresh(self,
                 asset_report_token,
                 days_requested,
-                options={}):
+                options=None):
         '''
         Create a new, refreshed asset report based on an existing asset report.
 
@@ -65,6 +65,7 @@ class AssetReport(API):
         :param  dict  options:              An optional dictionary. This is the
                                             same object used in `create`.
         '''
+        options = options or {}
 
         return self.client.post('/asset_report/refresh', {
             'asset_report_token': asset_report_token,

--- a/plaid/api/auth.py
+++ b/plaid/api/auth.py
@@ -6,7 +6,7 @@ class Auth(API):
 
     def get(self,
             access_token,
-            _options={},
+            _options=None,
             account_ids=None):
         '''
         Retrieve account and routing numbers for checking and savings accounts.
@@ -16,8 +16,7 @@ class Auth(API):
         :param  [str]   account_ids:    A list of account_ids to retrieve for
                                         the item. Optional.
         '''
-        options = {}
-        options.update(_options)
+        options = _options or {}
         if account_ids is not None:
             options['account_ids'] = account_ids
 

--- a/plaid/api/institutions.py
+++ b/plaid/api/institutions.py
@@ -19,15 +19,17 @@ class Institutions(API):
             'offset': offset,
         })
 
-    def get_by_id(self, institution_id, _options={}):
+    def get_by_id(self, institution_id, _options=None):
         '''
         Fetch a single institution by id.
 
         :param  str     institution_id:
         '''
+        options = _options or {}
+
         return self.client.post_public_key('/institutions/get_by_id', {
             'institution_id': institution_id,
-            'options': _options,
+            'options': options,
         })
 
     def search(self, query, _options={}, products=None):
@@ -38,8 +40,10 @@ class Institutions(API):
                                     institutions.
         :param  [str]    products:  Filter FIs by available products. Optional.
         '''
+        options = _options or {}
+
         return self.client.post_public_key('/institutions/search', {
             'query': query,
             'products': products,
-            'options': _options,
+            'options': options,
         })

--- a/plaid/api/item.py
+++ b/plaid/api/item.py
@@ -4,7 +4,7 @@ from plaid.api.api import API
 class Credentials(API):
     '''Item Credentials endpoints.'''
 
-    def update(self, access_token, credentials, _options={}):
+    def update(self, access_token, credentials, _options=None):
         '''
         Update the credentials associated with an item.
 
@@ -13,6 +13,8 @@ class Credentials(API):
 
         :param  dict     credentials:   See ``Item.create`` for details.
         '''
+        _options = _options or {}
+
         return self.client.post('/item/credentials/update', {
             'access_token': access_token,
             'credentials': credentials,
@@ -117,7 +119,7 @@ class Item(API):
                credentials,
                institution_id,
                initial_products,
-               _options={},
+               _options=None,
                transactions__start_date=None,
                transactions__end_date=None,
                transactions__await_results=None,
@@ -155,8 +157,10 @@ class Item(API):
 
         All dates should be formatted as ``YYYY-MM-DD``.
         '''
+        options = _options or {}
+
         transaction_options = {}
-        transaction_options.update(_options.get('transactions', {}))
+        transaction_options.update(options.get('transactions', {}))
         if transactions__start_date is not None:
             transaction_options['start_date'] = transactions__start_date
         if transactions__end_date is not None:
@@ -164,8 +168,6 @@ class Item(API):
         if transactions__await_results is not None:
             transaction_options['await_results'] = transactions__await_results
 
-        options = {}
-        options.update(_options)
         if transaction_options:
             options['transactions'] = transaction_options
         if webhook is not None:
@@ -178,7 +180,7 @@ class Item(API):
             'options': options,
         })
 
-    def mfa(self, access_token, mfa_type, responses, _options={}):
+    def mfa(self, access_token, mfa_type, responses, _options=None):
         '''
         Provide an MFA (Multi-Factor Authentication) response for an item.
 
@@ -186,6 +188,8 @@ class Item(API):
         :param  str     mfa_type:       The type of mfa answered (e.g. device)
         :param  [str]   responses:      The MFA response(s)
         '''
+        _options = _options or {}
+
         return self.client.post('/item/mfa', {
             'access_token': access_token,
             'mfa_type': mfa_type,

--- a/plaid/api/sandbox.py
+++ b/plaid/api/sandbox.py
@@ -21,7 +21,7 @@ class PublicToken(API):
     def create(self,
                institution_id,
                initial_products,
-               _options={},
+               _options=None,
                webhook=None):
         '''
         Generate a public token for sandbox testing.
@@ -32,8 +32,8 @@ class PublicToken(API):
 
         :param  str     webhook:
         '''
-        options = {}
-        options.update(_options)
+        options = _options or {}
+
         if webhook is not None:
             options['webhook'] = webhook
 

--- a/plaid/api/transactions.py
+++ b/plaid/api/transactions.py
@@ -8,7 +8,7 @@ class Transactions(API):
             access_token,
             start_date,
             end_date,
-            _options={},
+            _options=None,
             account_ids=None,
             count=None,
             offset=None,
@@ -33,8 +33,8 @@ class Transactions(API):
 
         All date should be formatted as ``YYYY-MM-DD``.
         '''
-        options = {}
-        options.update(_options)
+        options = _options or {}
+
         if account_ids is not None:
             options['account_ids'] = account_ids
         if count is not None:


### PR DESCRIPTION
Kwargs are evaluated import time and for objects (in this case the dict) the function is passed a reference to the same dict on each call. This is an anti-pattern because it introduces state in functions in an unexpected way (if the dict is mutated then subsequent function calls are affected by this mutation too).

This change is backwards compatible and removes risk of subtle and hard-to-identify bugs.