### PR TITLE
Run tests locally with tox to create parity with CI. pep8 as part of tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,18 @@
+#!make
+
 .PHONY: lint
 lint:
 	flake8 plaid
 
-
+# Requires tox to be installed and in the executable path
 .PHONY: test
 test: lint
-	py.test --cov plaid -s -rxs ./tests/
+	./.env tox
 
-
+# Setting up for local development
 .PHONY: setup
 setup:
 	pip install -r requirements.txt
-
 
 .PHONY: docs
 docs:

--- a/docs_source/conf.py
+++ b/docs_source/conf.py
@@ -20,7 +20,7 @@
 import os
 import sys
 sys.path.insert(0, os.path.abspath('..'))
-import plaid
+import plaid  # noqa: E402
 
 # -- General configuration ------------------------------------------------
 

--- a/plaid/api/income.py
+++ b/plaid/api/income.py
@@ -6,6 +6,7 @@ class Income(API):
     Income endpoints.
     (`HTTP docs <https://plaid.com/docs/api/#income>`__)
     '''
+
     def get(self, access_token):
         '''
         Retrieve income data associated with an item.

--- a/tests/integration/test_assets.py
+++ b/tests/integration/test_assets.py
@@ -9,6 +9,7 @@ from tests.integration.util import (
 
 access_token = None
 
+
 def setup_module(module):
     client = create_client()
     response = client.Item.create(
@@ -16,9 +17,11 @@ def setup_module(module):
     global access_token
     access_token = response['access_token']
 
+
 def teardown_module(module):
     client = create_client()
     client.Item.remove(access_token)
+
 
 def test_full_flow():
     client = create_client()
@@ -57,7 +60,8 @@ def test_full_flow():
 
     # create a filtered copy of the asset report
     account_ids_to_exclude = [report['items'][0]['accounts'][0]['account_id']]
-    response = client.AssetReport.filter(asset_report_token, account_ids_to_exclude)
+    response = client.AssetReport.filter(
+        asset_report_token, account_ids_to_exclude)
     assert response['asset_report_token'] is not None
 
     # create a refreshed copy of the asset report
@@ -85,6 +89,7 @@ def test_full_flow():
     response = client.AssetReport.remove(asset_report_token)
     removed = response['removed']
     assert removed
+
 
 def poll_for_asset_report(client, asset_report_token, retries=20):
     try:

--- a/tests/integration/test_income.py
+++ b/tests/integration/test_income.py
@@ -1,8 +1,7 @@
 from plaid.errors import ItemError
 from tests.integration.util import (
     create_client,
-    CREDENTIALS,
-    SANDBOX_INSTITUTION
+    CREDENTIALS
 )
 
 access_token = None

--- a/tests/integration/test_item.py
+++ b/tests/integration/test_item.py
@@ -151,6 +151,7 @@ def test_delete():
     delete_response = client.Item.delete(create_response['access_token'])
     assert delete_response['deleted']
 
+
 def test_remove():
     client = create_client()
     create_response = client.Item.create(
@@ -158,6 +159,7 @@ def test_remove():
 
     remove_response = client.Item.remove(create_response['access_token'])
     assert remove_response['removed']
+
 
 def test_public_token():
     client = create_client()
@@ -175,6 +177,7 @@ def test_public_token():
             create_response['public_token'])
         assert exchange_response['access_token'] is not None
 
+
 def test_sandbox_public_token():
     client = create_client()
     create_response = client.Sandbox.public_token.create(
@@ -185,6 +188,7 @@ def test_sandbox_public_token():
     exchange_response = client.Item.public_token.exchange(
         create_response['public_token'])
     assert exchange_response['access_token'] is not None
+
 
 def test_access_token_invalidate():
     client = create_client()

--- a/tests/integration/test_processor.py
+++ b/tests/integration/test_processor.py
@@ -1,9 +1,6 @@
 '''
 Client.Processor.* tests.
 '''
-
-from contextlib import contextmanager
-
 import pytest
 
 from plaid.errors import InvalidRequestError

--- a/tests/integration/util.py
+++ b/tests/integration/util.py
@@ -13,6 +13,7 @@ def create_client():
                   'sandbox',
                   api_version="2017-03-08")
 
+
 CREDENTIALS = {
     'username': 'user_good',
     'password': 'pass_good',

--- a/tox.ini
+++ b/tox.ini
@@ -6,4 +6,6 @@ passenv = *
 deps=
   -rrequirements.txt
 commands=
-  py.test --cov plaid -s -rxs ./tests/
+  coverage run --source=plaid/,tests/ -m pytest --strict {posargs}
+  coverage report -m --show-missing --fail-under 96
+  flake8 .


### PR DESCRIPTION
Makes make test run tox, the same way our CI does. Hopefully this makes for slightly faster iterations, and could help expose issues with different python versions. 

Also adding stricter requirements in terms of test coverage and code style.

I also think this new error message is more informative for missing `.env`:
```bash
bash-3.2$ make test
flake8 plaid
./.env tox
make: ./.env: No such file or directory
make: *** [test] Error 1
```