### PR TITLE
Fix build on CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,10 +6,9 @@ machine:
 
 dependencies:
   override:
-    - pip install flake8 requests tox tox-pyenv
+    - pip install tox tox-pyenv
     - pyenv local 2.7.10 3.6.0
 
 test:
   override:
-    - make lint
     - tox

--- a/tests/integration/test_assets.py
+++ b/tests/integration/test_assets.py
@@ -61,7 +61,9 @@ def test_full_flow():
 
     # The transactions in an Asset Report with Insights should have a non-null
     # `name` (when available).
-    assert report['items'][0]['accounts'][0]['transactions'][0]['name'] is not None
+    assert (
+        report['items'][0]['accounts'][0]['transactions'][0]['name']
+    ) is not None
 
     # retrieve the asset report as a PDF
     pdf = client.AssetReport.get_pdf(asset_report_token)

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -29,4 +29,3 @@ def test_from_response():
     assert cause.code == 'INTERNAL_SERVER_ERROR'
     assert cause.message == 'an unexpected error occurred'
     assert cause.item_id == '456'
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py27,py36
+envlist = py27,py37
 
 [testenv]
 passenv = *
 deps=
   -rrequirements.txt
 commands=
-  coverage run --source=plaid/,tests/ -m pytest --strict {posargs}
+  coverage run --source=plaid/,tests/ -m pytest -vv --strict tests/
   coverage report -m --show-missing --fail-under 96
-  flake8 .
+  flake8 --exclude=.git,__pycache__,.tox,venv .


### PR DESCRIPTION
Ah, so circle was installing dependencies in a venv/ folder besides tox, which caused tests in venv to run and fail.

Also, two new modules from merge weren't linted