### PR TITLE
run CI on python3.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py37
+envlist = py27,py36
 
 [testenv]
 passenv = *


### PR DESCRIPTION
This is what it was before, I was using 3.7 locally.