### PR TITLE
deprecate direct integration

### DIFF
--- a/plaid/api/item.py
+++ b/plaid/api/item.py
@@ -111,91 +111,8 @@ class Item(API):
     def __init__(self, client):
         super(Item, self).__init__(client)
         self.access_token = AccessToken(client)
-        self.credentials = Credentials(client)
         self.public_token = PublicToken(client)
         self.webhook = Webhook(client)
-
-    def create(self,
-               credentials,
-               institution_id,
-               initial_products,
-               _options=None,
-               transactions__start_date=None,
-               transactions__end_date=None,
-               transactions__await_results=None,
-               webhook=None):
-        '''
-        Add a bank account user/login to Plaid.
-
-        Returns either a successful response or a response indicating that MFA
-        (Multi Factor Authentication) is required.
-
-        :param  dict    credentials:                    A dictionary containing
-                                                        the fields
-                                                        ``username``,
-                                                        ``password``, and
-                                                        (optionally) ``pin``.
-        :param  str     institution_id:
-        :param  list    initial_products:               A list containing
-                                                        product names.
-        :param  str     transactions__start_date:       The date to begin the
-                                                        item's initial
-                                                        transaction pull.
-        :param  str     transactions__end_date:         The date to end the
-                                                        item's initial
-                                                        transaction pull.
-        :param  str     transactions__await_results:    If ``True``, wait for
-                                                        the initial
-                                                        transaction pull to
-                                                        complete before
-                                                        returning. Will
-                                                        increase the user wait
-                                                        time.
-        :param  str     webhook:                        The URL for a webhook
-                                                        associated with the
-                                                        item.
-
-        All dates should be formatted as ``YYYY-MM-DD``.
-        '''
-        options = _options or {}
-
-        transaction_options = {}
-        transaction_options.update(options.get('transactions', {}))
-        if transactions__start_date is not None:
-            transaction_options['start_date'] = transactions__start_date
-        if transactions__end_date is not None:
-            transaction_options['end_date'] = transactions__end_date
-        if transactions__await_results is not None:
-            transaction_options['await_results'] = transactions__await_results
-
-        if transaction_options:
-            options['transactions'] = transaction_options
-        if webhook is not None:
-            options['webhook'] = webhook
-
-        return self.client.post('/item/create', {
-            'credentials': credentials,
-            'institution_id': institution_id,
-            'initial_products': initial_products,
-            'options': options,
-        })
-
-    def mfa(self, access_token, mfa_type, responses, _options=None):
-        '''
-        Provide an MFA (Multi-Factor Authentication) response for an item.
-
-        :param  str     access_token:
-        :param  str     mfa_type:       The type of mfa answered (e.g. device)
-        :param  [str]   responses:      The MFA response(s)
-        '''
-        _options = _options or {}
-
-        return self.client.post('/item/mfa', {
-            'access_token': access_token,
-            'mfa_type': mfa_type,
-            'responses': responses,
-            'options': _options,
-        })
 
     def get(self, access_token):
         '''
@@ -205,19 +122,6 @@ class Item(API):
         :param  str     access_token:
         '''
         return self.client.post('/item/get', {
-            'access_token': access_token,
-        })
-
-    def delete(self, access_token):
-        '''
-        Delete an item.
-        (`HTTP docs <https://plaid.com/docs/api/#delete-an-item>`__)
-
-        This also deactivates the access_token.
-
-        :param  str     access_token:
-        '''
-        return self.client.post('/item/delete', {
             'access_token': access_token,
         })
 

--- a/plaid/api/sandbox.py
+++ b/plaid/api/sandbox.py
@@ -22,7 +22,10 @@ class PublicToken(API):
                institution_id,
                initial_products,
                _options=None,
-               webhook=None):
+               webhook=None,
+               transactions__start_date=None,
+               transactions__end_date=None,
+               ):
         '''
         Generate a public token for sandbox testing.
 
@@ -33,9 +36,17 @@ class PublicToken(API):
         :param  str     webhook:
         '''
         options = _options or {}
+        transaction_options = {}
+        transaction_options.update(options.get('transactions', {}))
 
         if webhook is not None:
             options['webhook'] = webhook
+        if transactions__start_date is not None:
+            transaction_options['start_date'] = transactions__start_date
+        if transactions__end_date is not None:
+            transaction_options['end_date'] = transactions__end_date
+        if transaction_options:
+            options['transactions'] = transaction_options
 
         return self.client.post_public_key('/sandbox/public_token/create', {
             'institution_id': institution_id,

--- a/plaid/api/sandbox.py
+++ b/plaid/api/sandbox.py
@@ -36,11 +36,12 @@ class PublicToken(API):
         :param  str     webhook:
         '''
         options = _options or {}
-        transaction_options = {}
-        transaction_options.update(options.get('transactions', {}))
 
         if webhook is not None:
             options['webhook'] = webhook
+
+        transaction_options = {}
+        transaction_options.update(options.get('transactions', {}))
         if transactions__start_date is not None:
             transaction_options['start_date'] = transactions__start_date
         if transactions__end_date is not None:

--- a/tests/integration/test_accounts.py
+++ b/tests/integration/test_accounts.py
@@ -1,6 +1,5 @@
 from tests.integration.util import (
     create_client,
-    CREDENTIALS,
     SANDBOX_INSTITUTION,
 )
 
@@ -9,8 +8,10 @@ access_token = None
 
 def setup_module(module):
     client = create_client()
-    pt_response = client.Sandbox.public_token.create(SANDBOX_INSTITUTION, ['transactions'])
-    exchange_response = client.Item.public_token.exchange(pt_response['public_token'])
+    pt_response = client.Sandbox.public_token.create(
+        SANDBOX_INSTITUTION, ['transactions'])
+    exchange_response = client.Item.public_token.exchange(
+        pt_response['public_token'])
     global access_token
     access_token = exchange_response['access_token']
 

--- a/tests/integration/test_accounts.py
+++ b/tests/integration/test_accounts.py
@@ -9,10 +9,10 @@ access_token = None
 
 def setup_module(module):
     client = create_client()
-    response = client.Item.create(
-        CREDENTIALS, SANDBOX_INSTITUTION, ['transactions'])
+    pt_response = client.Sandbox.public_token.create(SANDBOX_INSTITUTION, ['transactions'])
+    exchange_response = client.Item.public_token.exchange(pt_response['public_token'])
     global access_token
-    access_token = response['access_token']
+    access_token = exchange_response['access_token']
 
 
 def teardown_module(module):

--- a/tests/integration/test_assets.py
+++ b/tests/integration/test_assets.py
@@ -12,10 +12,10 @@ access_token = None
 
 def setup_module(module):
     client = create_client()
-    response = client.Item.create(
-        CREDENTIALS, SANDBOX_INSTITUTION, ['assets'])
+    pt_response = client.Sandbox.public_token.create(SANDBOX_INSTITUTION, ['assets'])
+    exchange_response = client.Item.public_token.exchange(pt_response['public_token'])
     global access_token
-    access_token = response['access_token']
+    access_token = exchange_response['access_token']
 
 
 def teardown_module(module):

--- a/tests/integration/test_assets.py
+++ b/tests/integration/test_assets.py
@@ -2,7 +2,6 @@ import time
 from plaid.errors import PlaidError
 from tests.integration.util import (
     create_client,
-    CREDENTIALS,
     SANDBOX_INSTITUTION,
 )
 
@@ -12,8 +11,10 @@ access_token = None
 
 def setup_module(module):
     client = create_client()
-    pt_response = client.Sandbox.public_token.create(SANDBOX_INSTITUTION, ['assets'])
-    exchange_response = client.Item.public_token.exchange(pt_response['public_token'])
+    pt_response = client.Sandbox.public_token.create(
+        SANDBOX_INSTITUTION, ['assets'])
+    exchange_response = client.Item.public_token.exchange(
+        pt_response['public_token'])
     global access_token
     access_token = exchange_response['access_token']
 

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -9,10 +9,10 @@ access_token = None
 
 def setup_module(module):
     client = create_client()
-    response = client.Item.create(
-        CREDENTIALS, SANDBOX_INSTITUTION, ['auth'])
+    pt_response = client.Sandbox.public_token.create(SANDBOX_INSTITUTION, ['auth'])
+    exchange_response = client.Item.public_token.exchange(pt_response['public_token'])
     global access_token
-    access_token = response['access_token']
+    access_token = exchange_response['access_token']
 
 
 def teardown_module(module):

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -1,6 +1,5 @@
 from tests.integration.util import (
     create_client,
-    CREDENTIALS,
     SANDBOX_INSTITUTION,
 )
 
@@ -9,8 +8,10 @@ access_token = None
 
 def setup_module(module):
     client = create_client()
-    pt_response = client.Sandbox.public_token.create(SANDBOX_INSTITUTION, ['auth'])
-    exchange_response = client.Item.public_token.exchange(pt_response['public_token'])
+    pt_response = client.Sandbox.public_token.create(
+        SANDBOX_INSTITUTION, ['auth'])
+    exchange_response = client.Item.public_token.exchange(
+        pt_response['public_token'])
     global access_token
     access_token = exchange_response['access_token']
 

--- a/tests/integration/test_credit_details.py
+++ b/tests/integration/test_credit_details.py
@@ -1,6 +1,5 @@
 from tests.integration.util import (
     create_client,
-    CREDENTIALS,
     SANDBOX_INSTITUTION,
 )
 
@@ -9,8 +8,10 @@ access_token = None
 
 def setup_module(module):
     client = create_client()
-    pt_response = client.Sandbox.public_token.create(SANDBOX_INSTITUTION, ['credit_details'])
-    exchange_response = client.Item.public_token.exchange(pt_response['public_token'])
+    pt_response = client.Sandbox.public_token.create(
+        SANDBOX_INSTITUTION, ['credit_details'])
+    exchange_response = client.Item.public_token.exchange(
+        pt_response['public_token'])
     global access_token
     access_token = exchange_response['access_token']
 

--- a/tests/integration/test_credit_details.py
+++ b/tests/integration/test_credit_details.py
@@ -9,10 +9,10 @@ access_token = None
 
 def setup_module(module):
     client = create_client()
-    response = client.Item.create(
-        CREDENTIALS, SANDBOX_INSTITUTION, ['credit_details'])
+    pt_response = client.Sandbox.public_token.create(SANDBOX_INSTITUTION, ['credit_details'])
+    exchange_response = client.Item.public_token.exchange(pt_response['public_token'])
     global access_token
-    access_token = response['access_token']
+    access_token = exchange_response['access_token']
 
 
 def teardown_module(module):

--- a/tests/integration/test_identity.py
+++ b/tests/integration/test_identity.py
@@ -9,10 +9,10 @@ access_token = None
 
 def setup_module(module):
     client = create_client()
-    response = client.Item.create(
-        CREDENTIALS, SANDBOX_INSTITUTION, ['identity'])
+    pt_response = client.Sandbox.public_token.create(SANDBOX_INSTITUTION, ['identity'])
+    exchange_response = client.Item.public_token.exchange(pt_response['public_token'])
     global access_token
-    access_token = response['access_token']
+    access_token = exchange_response['access_token']
 
 
 def teardown_module(module):

--- a/tests/integration/test_identity.py
+++ b/tests/integration/test_identity.py
@@ -1,6 +1,5 @@
 from tests.integration.util import (
     create_client,
-    CREDENTIALS,
     SANDBOX_INSTITUTION,
 )
 
@@ -9,8 +8,10 @@ access_token = None
 
 def setup_module(module):
     client = create_client()
-    pt_response = client.Sandbox.public_token.create(SANDBOX_INSTITUTION, ['identity'])
-    exchange_response = client.Item.public_token.exchange(pt_response['public_token'])
+    pt_response = client.Sandbox.public_token.create(
+        SANDBOX_INSTITUTION, ['identity'])
+    exchange_response = client.Item.public_token.exchange(
+        pt_response['public_token'])
     global access_token
     access_token = exchange_response['access_token']
 

--- a/tests/integration/test_income.py
+++ b/tests/integration/test_income.py
@@ -1,7 +1,7 @@
 from plaid.errors import ItemError
 from tests.integration.util import (
     create_client,
-    CREDENTIALS
+    SANDBOX_INSTITUTION
 )
 
 access_token = None
@@ -9,10 +9,10 @@ access_token = None
 
 def setup_module(module):
     client = create_client()
-    response = client.Item.create(
-        CREDENTIALS, 'ins_1', ['income'])
+    pt_response = client.Sandbox.public_token.create(SANDBOX_INSTITUTION, ['income'])
+    exchange_response = client.Item.public_token.exchange(pt_response['public_token'])
     global access_token
-    access_token = response['access_token']
+    access_token = exchange_response['access_token']
 
 
 def teardown_module(module):

--- a/tests/integration/test_income.py
+++ b/tests/integration/test_income.py
@@ -9,8 +9,10 @@ access_token = None
 
 def setup_module(module):
     client = create_client()
-    pt_response = client.Sandbox.public_token.create(SANDBOX_INSTITUTION, ['income'])
-    exchange_response = client.Item.public_token.exchange(pt_response['public_token'])
+    pt_response = client.Sandbox.public_token.create(
+        SANDBOX_INSTITUTION, ['income'])
+    exchange_response = client.Item.public_token.exchange(
+        pt_response['public_token'])
     global access_token
     access_token = exchange_response['access_token']
 

--- a/tests/integration/test_item.py
+++ b/tests/integration/test_item.py
@@ -9,13 +9,8 @@ runner.
 
 from contextlib import contextmanager
 
-import pytest
-
-from plaid.errors import ItemError
-
 from tests.integration.util import (
     create_client,
-    CREDENTIALS,
     SANDBOX_INSTITUTION,
 )
 
@@ -28,19 +23,25 @@ def ensure_item_removed(access_token):
     finally:
         create_client().Item.remove(access_token)
 
+
 def test_get():
     client = create_client()
-    pt_response = client.Sandbox.public_token.create(SANDBOX_INSTITUTION, ['transactions'])
-    exchange_response = client.Item.public_token.exchange(pt_response['public_token'])
+    pt_response = client.Sandbox.public_token.create(
+        SANDBOX_INSTITUTION, ['transactions'])
+    exchange_response = client.Item.public_token.exchange(
+        pt_response['public_token'])
 
     with ensure_item_removed(exchange_response['access_token']):
         get_response = client.Item.get(exchange_response['access_token'])
         assert get_response['item'] is not None
 
+
 def test_remove():
     client = create_client()
-    pt_response = client.Sandbox.public_token.create(SANDBOX_INSTITUTION, ['transactions'])
-    exchange_response = client.Item.public_token.exchange(pt_response['public_token'])
+    pt_response = client.Sandbox.public_token.create(
+        SANDBOX_INSTITUTION, ['transactions'])
+    exchange_response = client.Item.public_token.exchange(
+        pt_response['public_token'])
 
     remove_response = client.Item.remove(exchange_response['access_token'])
     assert remove_response['removed']
@@ -48,8 +49,10 @@ def test_remove():
 
 def test_public_token():
     client = create_client()
-    pt_response = client.Sandbox.public_token.create(SANDBOX_INSTITUTION, ['transactions'])
-    exchange_response = client.Item.public_token.exchange(pt_response['public_token'])
+    pt_response = client.Sandbox.public_token.create(
+        SANDBOX_INSTITUTION, ['transactions'])
+    exchange_response = client.Item.public_token.exchange(
+        pt_response['public_token'])
     with ensure_item_removed(exchange_response['access_token']):
         assert pt_response['public_token'] is not None
         assert exchange_response['access_token'] is not None
@@ -69,8 +72,10 @@ def test_sandbox_public_token():
 
 def test_access_token_invalidate():
     client = create_client()
-    pt_response = client.Sandbox.public_token.create(SANDBOX_INSTITUTION, ['transactions'])
-    exchange_response = client.Item.public_token.exchange(pt_response['public_token'])
+    pt_response = client.Sandbox.public_token.create(
+        SANDBOX_INSTITUTION, ['transactions'])
+    exchange_response = client.Item.public_token.exchange(
+        pt_response['public_token'])
 
     try:
         invalidate_response = client.Item.access_token.invalidate(
@@ -81,13 +86,17 @@ def test_access_token_invalidate():
         with ensure_item_removed(exchange_response['access_token']):
             raise
 
+
 def test_webhook_update():
     client = create_client()
-    pt_response = client.Sandbox.public_token.create(SANDBOX_INSTITUTION, ['transactions'])
-    exchange_response = client.Item.public_token.exchange(pt_response['public_token'])
+    pt_response = client.Sandbox.public_token.create(
+        SANDBOX_INSTITUTION, ['transactions'])
+    exchange_response = client.Item.public_token.exchange(
+        pt_response['public_token'])
 
     with ensure_item_removed(exchange_response['access_token']):
         webhook_response = client.Item.webhook.update(
-            exchange_response['access_token'], 'https://plaid.com/webhook-test')
+            exchange_response['access_token'],
+            'https://plaid.com/webhook-test')
         assert (webhook_response['item']['webhook'] ==
                 'https://plaid.com/webhook-test')

--- a/tests/integration/test_item.py
+++ b/tests/integration/test_item.py
@@ -16,10 +16,6 @@ from plaid.errors import ItemError
 from tests.integration.util import (
     create_client,
     CREDENTIALS,
-    INVALID_CREDENTIALS,
-    MFA_DEVICE_CREDENTIALS,
-    MFA_QUESTIONS_CREDENTIALS,
-    MFA_SELECTIONS_CREDENTIALS,
     SANDBOX_INSTITUTION,
 )
 
@@ -32,149 +28,30 @@ def ensure_item_removed(access_token):
     finally:
         create_client().Item.remove(access_token)
 
-
-def test_create():
-    client = create_client()
-    response = client.Item.create(
-        CREDENTIALS, SANDBOX_INSTITUTION, ['transactions'])
-
-    with ensure_item_removed(response['access_token']):
-        assert response['access_token'] is not None
-        assert response['item']['billed_products'] == ['transactions']
-        assert response['item']['institution_id'] == SANDBOX_INSTITUTION
-        assert response.get('mfa_type') is None
-
-
-def test_create_invalid_credentials():
-    client = create_client()
-    with pytest.raises(ItemError) as e:
-        client.Item.create(
-            INVALID_CREDENTIALS, SANDBOX_INSTITUTION, ['transactions'])
-        assert e.code == 'INVALID_CREDENTIALS'
-
-
-def test_create_with_options():
-    client = create_client()
-    response = client.Item.create(
-        CREDENTIALS,
-        SANDBOX_INSTITUTION,
-        ['transactions'],
-        transactions__start_date='2016-01-01',
-        transactions__end_date='2016-02-01',
-        transactions__await_results=True,
-        webhook='https://plaid.com/webhook-test',
-    )
-
-    with ensure_item_removed(response['access_token']):
-        assert response['access_token'] is not None
-        assert response['item'] is not None
-        assert response['item']['webhook'] == 'https://plaid.com/webhook-test'
-
-
-def test_mfa_device():
-    client = create_client()
-    item_response = client.Item.create(
-        MFA_DEVICE_CREDENTIALS, SANDBOX_INSTITUTION, ['transactions'])
-
-    with ensure_item_removed(item_response['access_token']):
-        assert item_response['mfa_type'] == 'device_list'
-
-        # Send MFA indicating which device should receive the code
-        device = item_response['device_list'][0]
-        mfa_response = client.Item.mfa(
-            item_response['access_token'],
-            'device_list',
-            [device['device_id']],
-        )
-        assert mfa_response['mfa_type'] == 'device'
-
-        # Send MFA with the actual code
-        mfa_response = client.Item.mfa(
-            item_response['access_token'], 'device', ['1234'])
-        assert mfa_response['item'] is not None
-
-
-def test_mfa_questions():
-    client = create_client()
-    item_response = client.Item.create(
-        MFA_QUESTIONS_CREDENTIALS, SANDBOX_INSTITUTION, ['transactions'])
-
-    with ensure_item_removed(item_response['access_token']):
-        assert item_response['mfa_type'] == 'questions'
-
-        mfa_response = client.Item.mfa(
-            item_response['access_token'], 'questions', ['answer_0_0'])
-        assert mfa_response['item'] is not None
-
-
-def test_mfa_selections():
-    client = create_client()
-    item_response = client.Item.create(
-        MFA_SELECTIONS_CREDENTIALS, SANDBOX_INSTITUTION, ['transactions'])
-
-    with ensure_item_removed(item_response['access_token']):
-        assert item_response['mfa_type'] == 'selections'
-
-        mfa_response = client.Item.mfa(
-            item_response['access_token'], 'selections', ['tomato', 'ketchup'])
-        assert mfa_response['item'] is not None
-
-
-def test_credentials_update():
-    client = create_client()
-    create_response = client.Item.create(
-        CREDENTIALS, SANDBOX_INSTITUTION, ['transactions'])
-
-    with ensure_item_removed(create_response['access_token']):
-        client.Sandbox.item.reset_login(create_response['access_token'])
-
-        update_response = client.Item.credentials.update(
-            create_response['access_token'], CREDENTIALS)
-        assert update_response['item'] is not None
-
-
 def test_get():
     client = create_client()
-    create_response = client.Item.create(
-        CREDENTIALS, SANDBOX_INSTITUTION, ['transactions'])
+    pt_response = client.Sandbox.public_token.create(SANDBOX_INSTITUTION, ['transactions'])
+    exchange_response = client.Item.public_token.exchange(pt_response['public_token'])
 
-    with ensure_item_removed(create_response['access_token']):
-        get_response = client.Item.get(create_response['access_token'])
+    with ensure_item_removed(exchange_response['access_token']):
+        get_response = client.Item.get(exchange_response['access_token'])
         assert get_response['item'] is not None
-
-
-def test_delete():
-    client = create_client()
-    create_response = client.Item.create(
-        CREDENTIALS, SANDBOX_INSTITUTION, ['transactions'])
-
-    delete_response = client.Item.delete(create_response['access_token'])
-    assert delete_response['deleted']
-
 
 def test_remove():
     client = create_client()
-    create_response = client.Item.create(
-        CREDENTIALS, SANDBOX_INSTITUTION, ['transactions'])
+    pt_response = client.Sandbox.public_token.create(SANDBOX_INSTITUTION, ['transactions'])
+    exchange_response = client.Item.public_token.exchange(pt_response['public_token'])
 
-    remove_response = client.Item.remove(create_response['access_token'])
+    remove_response = client.Item.remove(exchange_response['access_token'])
     assert remove_response['removed']
 
 
 def test_public_token():
     client = create_client()
-    item_response = client.Item.create(
-        CREDENTIALS, SANDBOX_INSTITUTION, ['transactions'])
-
-    with ensure_item_removed(item_response['access_token']):
-        # access token -> public token
-        create_response = client.Item.public_token.create(
-            item_response['access_token'])
-        assert create_response['public_token'] is not None
-
-        # public token -> access token
-        exchange_response = client.Item.public_token.exchange(
-            create_response['public_token'])
+    pt_response = client.Sandbox.public_token.create(SANDBOX_INSTITUTION, ['transactions'])
+    exchange_response = client.Item.public_token.exchange(pt_response['public_token'])
+    with ensure_item_removed(exchange_response['access_token']):
+        assert pt_response['public_token'] is not None
         assert exchange_response['access_token'] is not None
 
 
@@ -192,26 +69,25 @@ def test_sandbox_public_token():
 
 def test_access_token_invalidate():
     client = create_client()
-    create_response = client.Item.create(
-        CREDENTIALS, SANDBOX_INSTITUTION, ['transactions'])
+    pt_response = client.Sandbox.public_token.create(SANDBOX_INSTITUTION, ['transactions'])
+    exchange_response = client.Item.public_token.exchange(pt_response['public_token'])
 
     try:
         invalidate_response = client.Item.access_token.invalidate(
-            create_response['access_token'])
+            exchange_response['access_token'])
         with ensure_item_removed(invalidate_response['new_access_token']):
             assert invalidate_response['new_access_token'] is not None
     except Exception:
-        with ensure_item_removed(create_response['access_token']):
+        with ensure_item_removed(exchange_response['access_token']):
             raise
-
 
 def test_webhook_update():
     client = create_client()
-    create_response = client.Item.create(
-        CREDENTIALS, SANDBOX_INSTITUTION, ['transactions'])
+    pt_response = client.Sandbox.public_token.create(SANDBOX_INSTITUTION, ['transactions'])
+    exchange_response = client.Item.public_token.exchange(pt_response['public_token'])
 
-    with ensure_item_removed(create_response['access_token']):
+    with ensure_item_removed(exchange_response['access_token']):
         webhook_response = client.Item.webhook.update(
-            create_response['access_token'], 'https://plaid.com/webhook-test')
+            exchange_response['access_token'], 'https://plaid.com/webhook-test')
         assert (webhook_response['item']['webhook'] ==
                 'https://plaid.com/webhook-test')

--- a/tests/integration/test_transactions.py
+++ b/tests/integration/test_transactions.py
@@ -11,20 +11,35 @@ access_token = None
 
 def setup_module(module):
     client = create_client()
-    pt_response = client.Sandbox.public_token.create(SANDBOX_INSTITUTION, ['transactions'],
+    pt_response = client.Sandbox.public_token.create(
+        SANDBOX_INSTITUTION, ['transactions'],
         transactions__start_date='2016-01-01',
         transactions__end_date='2017-01-01',
     )
-    exchange_response = client.Item.public_token.exchange(pt_response['public_token'])
+    exchange_response = client.Item.public_token.exchange(
+        pt_response['public_token'])
     global access_token
     access_token = exchange_response['access_token']
 
-def get_transactions_with_retries(client, access_token, start_date, end_date, account_ids=None, count=None, offset=None, num_retries=5):
+
+def get_transactions_with_retries(client,
+                                  access_token,
+                                  start_date,
+                                  end_date,
+                                  account_ids=None,
+                                  count=None,
+                                  offset=None,
+                                  num_retries=5):
     response = None
     for i in range(num_retries):
         while True:
             try:
-                response = client.Transactions.get(access_token, start_date, end_date, account_ids=account_ids, count=count, offset=offset)
+                response = client.Transactions.get(access_token,
+                                                   start_date,
+                                                   end_date,
+                                                   account_ids=account_ids,
+                                                   count=count,
+                                                   offset=offset)
             except ItemError as ie:
                 if ie.code == u'PRODUCT_NOT_READY':
                     time.sleep(5)
@@ -34,25 +49,40 @@ def get_transactions_with_retries(client, access_token, start_date, end_date, ac
             break
     return response
 
+
 def teardown_module(module):
     client = create_client()
     client.Item.remove(access_token)
 
+
 def test_get():
     client = create_client()
 
-    response = get_transactions_with_retries(client, access_token, '2016-01-01', '2017-01-01', num_retries=5)
+    response = get_transactions_with_retries(client,
+                                             access_token,
+                                             '2016-01-01',
+                                             '2017-01-01',
+                                             num_retries=5)
     assert response['accounts'] is not None
     assert response['transactions'] is not None
 
     # get transactions for selected accounts
     account_id = response['accounts'][0]['account_id']
     response = get_transactions_with_retries(client,
-        access_token, '2016-01-01', '2017-01-01', account_ids=[account_id], num_retries=5)
+                                             access_token,
+                                             '2016-01-01',
+                                             '2017-01-01',
+                                             account_ids=[account_id],
+                                             num_retries=5)
     assert response['transactions'] is not None
+
 
 def test_get_with_options():
     client = create_client()
     response = get_transactions_with_retries(client,
-        access_token, '2016-01-01', '2017-01-01', count=2, offset=1)
+                                             access_token,
+                                             '2016-01-01',
+                                             '2017-01-01',
+                                             count=2,
+                                             offset=1)
     assert len(response['transactions']) == 2

--- a/tests/integration/test_transactions.py
+++ b/tests/integration/test_transactions.py
@@ -1,6 +1,8 @@
+import time
+
+from plaid.errors import ItemError
 from tests.integration.util import (
     create_client,
-    CREDENTIALS,
     SANDBOX_INSTITUTION,
 )
 
@@ -9,41 +11,48 @@ access_token = None
 
 def setup_module(module):
     client = create_client()
-    response = client.Item.create(
-        CREDENTIALS,
-        SANDBOX_INSTITUTION,
-        ['transactions'],
+    pt_response = client.Sandbox.public_token.create(SANDBOX_INSTITUTION, ['transactions'],
         transactions__start_date='2016-01-01',
         transactions__end_date='2017-01-01',
-        transactions__await_results=True,
     )
+    exchange_response = client.Item.public_token.exchange(pt_response['public_token'])
     global access_token
-    access_token = response['access_token']
+    access_token = exchange_response['access_token']
 
+def get_transactions_with_retries(client, access_token, start_date, end_date, account_ids=None, count=None, offset=None, num_retries=5):
+    response = None
+    for i in range(num_retries):
+        while True:
+            try:
+                response = client.Transactions.get(access_token, start_date, end_date, account_ids=account_ids, count=count, offset=offset)
+            except ItemError as ie:
+                if ie.code == u'PRODUCT_NOT_READY':
+                    time.sleep(5)
+                    continue
+                else:
+                    raise ie
+            break
+    return response
 
 def teardown_module(module):
     client = create_client()
     client.Item.remove(access_token)
 
-
 def test_get():
     client = create_client()
 
-    # get transactions for all accounts
-    response = client.Transactions.get(
-        access_token, '2016-01-01', '2017-01-01')
+    response = get_transactions_with_retries(client, access_token, '2016-01-01', '2017-01-01', num_retries=5)
     assert response['accounts'] is not None
     assert response['transactions'] is not None
 
     # get transactions for selected accounts
     account_id = response['accounts'][0]['account_id']
-    response = client.Transactions.get(
-        access_token, '2016-01-01', '2017-01-01', account_ids=[account_id])
+    response = get_transactions_with_retries(client,
+        access_token, '2016-01-01', '2017-01-01', account_ids=[account_id], num_retries=5)
     assert response['transactions'] is not None
-
 
 def test_get_with_options():
     client = create_client()
-    response = client.Transactions.get(
+    response = get_transactions_with_retries(client,
         access_token, '2016-01-01', '2017-01-01', count=2, offset=1)
     assert len(response['transactions']) == 2

--- a/tests/integration/test_transactions.py
+++ b/tests/integration/test_transactions.py
@@ -32,21 +32,20 @@ def get_transactions_with_retries(client,
                                   num_retries=5):
     response = None
     for i in range(num_retries):
-        while True:
-            try:
-                response = client.Transactions.get(access_token,
-                                                   start_date,
-                                                   end_date,
-                                                   account_ids=account_ids,
-                                                   count=count,
-                                                   offset=offset)
-            except ItemError as ie:
-                if ie.code == u'PRODUCT_NOT_READY':
-                    time.sleep(5)
-                    continue
-                else:
-                    raise ie
-            break
+        try:
+            response = client.Transactions.get(access_token,
+                                               start_date,
+                                               end_date,
+                                               account_ids=account_ids,
+                                               count=count,
+                                               offset=offset)
+        except ItemError as ie:
+            if ie.code == u'PRODUCT_NOT_READY':
+                time.sleep(5)
+                continue
+            else:
+                raise ie
+        break
     return response
 
 

--- a/tests/integration/util.py
+++ b/tests/integration/util.py
@@ -14,31 +14,6 @@ def create_client():
                   api_version="2017-03-08")
 
 
-CREDENTIALS = {
-    'username': 'user_good',
-    'password': 'pass_good',
-}
-
-MFA_DEVICE_CREDENTIALS = {
-    'username': 'user_good',
-    'password': 'mfa_device',
-}
-
-MFA_SELECTIONS_CREDENTIALS = {
-    'username': 'user_good',
-    'password': 'mfa_selections',
-}
-
-MFA_QUESTIONS_CREDENTIALS = {
-    'username': 'user_good',
-    'password': 'mfa_questions_1_1'
-}
-
-INVALID_CREDENTIALS = {
-    'username': 'user_bad',
-    'password': 'pass_bad',
-}
-
 SANDBOX_INSTITUTION = 'ins_109508'
 SANDBOX_INSTITUTION_NAME = 'First Platypus Bank'
 


### PR DESCRIPTION
- Deprecate direct integration as it is no longer supported
- Remove deprecated `/item/delete` in favor of `/item/remove`

These are both breaking changes - this will be released as a major version bump.