### PR TITLE
Pass in extra variable for account subtype filtering

### DIFF
--- a/plaid/api/institutions.py
+++ b/plaid/api/institutions.py
@@ -36,18 +36,22 @@ class Institutions(API):
             'options': options,
         })
 
-    def search(self, query, _options={}, products=None):
+    def search(self, query, products=None, account_filter=None, _options={}):
         '''
         Search all institutions by name.
 
-        :param  str      query:     Query against the full list of
-                                    institutions.
-        :param  [str]    products:  Filter FIs by available products. Optional.
+        :param  str      query:           Query against the full list of
+                                          institutions.
+        :param  [str]    products:        Filter FIs by available products.
+                                          Optional.
+        :param  dict     account_filter:  Filter FIs with specific account
+                                          types. Optional.
         '''
         options = _options or {}
 
         return self.client.post_public_key('/institutions/search', {
             'query': query,
             'products': products,
+            'account_filter': account_filter,
             'options': options,
         })

--- a/tests/integration/test_institutions.py
+++ b/tests/integration/test_institutions.py
@@ -57,6 +57,17 @@ def test_search_with_products():
     assert len(response['institutions']) >= 1
 
 
+def test_search_with_account_filter():
+    client = create_client()
+    response = client.Institutions.search(
+        SANDBOX_INSTITUTION_NAME, products=['liabilities'],
+        account_filter={
+            "loans": ["student"]
+        }
+    )
+    assert len(response['institutions']) >= 1
+
+
 def test_search_with_include_optional_metadata():
     client = create_client()
     response = client.Institutions.search(


### PR DESCRIPTION
We will now pass the extra variable `account_filter` when hitting the endpoint `/institutions/search` in order to support account subtype filtering.