### PR TITLE
Add support for user data in /item/add_token/create

### DIFF
--- a/plaid/api/item.py
+++ b/plaid/api/item.py
@@ -11,7 +11,7 @@ class AddToken(API):
         :param  dict user:  An optional dictionary with additional user data.
         '''
         return self.client.post('/item/add_token/create', {
-            'user': user
+            'user': user,
         })
 
 

--- a/plaid/api/item.py
+++ b/plaid/api/item.py
@@ -3,12 +3,16 @@ from plaid.api.api import API
 
 class AddToken(API):
     '''Endpoints for managing item add tokens. BETA.'''
-    def create(self):
+    def create(self, user=None):
         '''
         Create a Link item add token.
         Undocumented - beta endpoint.
+
+        :param  dict user:  An optional dictionary with additional user data.
         '''
-        return self.client.post('/item/add_token/create', {})
+        return self.client.post('/item/add_token/create', {
+            'user': user
+        })
 
 
 class PublicToken(API):

--- a/tests/integration/test_item.py
+++ b/tests/integration/test_item.py
@@ -63,6 +63,18 @@ def test_add_token():
     assert create_response['expiration'] is not None
 
 
+def test_add_token_with_user():
+    client = create_client()
+    user = {
+        'phone_number': '+1 415 555 0123',
+        'email_address': 'example@plaid.com',
+        'phone_number_verified_time': '2020-01-01T00:00:00Z',
+    }
+    create_response = client.Item.add_token.create(user=user)
+    assert create_response['add_token'] is not None
+    assert create_response['expiration'] is not None
+
+
 def test_public_token():
     client = create_client()
     pt_response = client.Sandbox.public_token.create(


### PR DESCRIPTION
Update the beta `/item/add_token/create` with support for additional user data, which enables more features for returning users.