### PR TITLE
Update PUBLISH.md

### DIFF
--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -8,6 +8,7 @@ Follow these steps sequentially to prepare a new release to Pypi:
 
 - Increment the library version in `plaid/version.py` by following [semantic versioning guidelines](https://semver.org/)
 - Update the `CHANGELOG.md` with the release version and relevant comments and changes
+- Build the updated docs with `make docs`
 - Commit the change, create a Pull Request, and obtain approval from a Plaid team member
 - Merge the commit into `master`, and pull down the latest changes locally from `master`
 


### PR DESCRIPTION
Often, contributors will forget to regenerate the docs with their changes so publishers should make sure to do so when releasing