### PR TITLE
Add support for issuing HTTP requests via requests.Session instance

### DIFF
--- a/plaid/api/accounts.py
+++ b/plaid/api/accounts.py
@@ -7,13 +7,16 @@ class Balance(API):
     def get(self,
             access_token,
             _options=None,
-            account_ids=None):
+            account_ids=None,
+            session=None):
         '''
         Retrieve real-time balance information for accounts.
 
         :param  str     access_token:
         :param  [str]   account_ids:    A list of account_ids to retrieve for
                                         the item. Optional.
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
         options = _options or {}
         if account_ids is not None:
@@ -22,7 +25,7 @@ class Balance(API):
         return self.client.post('/accounts/balance/get', {
             'access_token': access_token,
             'options': options,
-        })
+        }, session=session)
 
 
 class Accounts(API):
@@ -41,13 +44,16 @@ class Accounts(API):
     def get(self,
             access_token,
             _options=None,
-            account_ids=None):
+            account_ids=None,
+            session=None):
         '''
         Retrieve high-level account information for an Item.
 
         :param  str     access_token:
         :param  [str]   account_ids:    A list of account_ids to retrieve for
                                         the item. Optional.
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
         options = _options or {}
         if account_ids is not None:
@@ -56,4 +62,4 @@ class Accounts(API):
         return self.client.post('/accounts/get', {
             'access_token': access_token,
             'options': options,
-        })
+        }, session=session)

--- a/plaid/api/assets.py
+++ b/plaid/api/assets.py
@@ -12,7 +12,8 @@ class AssetReport(API):
     def create(self,
                access_tokens,
                days_requested,
-               options=None):
+               options=None,
+               session=None):
         '''
         Create an asset report.
 
@@ -24,6 +25,8 @@ class AssetReport(API):
         :param  dict    options:        An optional dictionary. For more
                                         information on the options object, see
                                         the documentation site listed above.
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
         options = options or {}
 
@@ -31,11 +34,12 @@ class AssetReport(API):
             'access_tokens': access_tokens,
             'days_requested': days_requested,
             'options': options,
-        })
+        }, session=session)
 
     def filter(self,
                asset_report_token,
-               account_ids_to_exclude):
+               account_ids_to_exclude,
+               session=None):
         '''
         Create a new, filtered asset report based on an existing asset report.
 
@@ -44,16 +48,19 @@ class AssetReport(API):
         :param  [str] account_ids_to_exclude:   A list of account IDs to
                                                 exclude from the new Asset
                                                 Report.
+        :param  object  session:                A requests.Session instance to use for
+                                                making HTTP requests. Optional.
         '''
         return self.client.post('/asset_report/filter', {
             'asset_report_token': asset_report_token,
             'account_ids_to_exclude': account_ids_to_exclude,
-        })
+        }, session=session)
 
     def refresh(self,
                 asset_report_token,
                 days_requested,
-                options=None):
+                options=None,
+                session=None):
         '''
         Create a new, refreshed asset report based on an existing asset report.
 
@@ -64,6 +71,8 @@ class AssetReport(API):
                                             Asset Report.
         :param  dict  options:              An optional dictionary. This is the
                                             same object used in `create`.
+        :param  object  session:            A requests.Session instance to use for
+                                            making HTTP requests. Optional.
         '''
         options = options or {}
 
@@ -71,11 +80,12 @@ class AssetReport(API):
             'asset_report_token': asset_report_token,
             'days_requested': days_requested,
             'options': options,
-        })
+        }, session=session)
 
     def get(self,
             asset_report_token,
-            include_insights=False):
+            include_insights=False,
+            session=None):
         '''
         Retrieves an asset report.
 
@@ -86,38 +96,46 @@ class AssetReport(API):
                                             report as an Asset Report with
                                             Insights. For more, see
                                             https://plaid.com/docs/#retrieve-json-report-request.
+        :param  object  session:            A requests.Session instance to use for
+                                            making HTTP requests. Optional.
         '''
 
         return self.client.post('/asset_report/get', {
             'asset_report_token': asset_report_token,
             'include_insights': include_insights,
-        })
+        }, session=session)
 
     def get_pdf(self,
-                asset_report_token):
+                asset_report_token,
+                session=None):
         '''
         Retrieves an asset report in the PDF format.
 
         :param  str   asset_report_token:   The asset report token for the
                                             asset report you created.
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
 
         return self.client.post('/asset_report/pdf/get', {
             'asset_report_token': asset_report_token,
-        }, is_json=False)
+        }, is_json=False, session=session)
 
     def remove(self,
-               asset_report_token):
+               asset_report_token,
+               session=None):
         '''
         Retrieves an asset report in the PDF format.
 
         :param  str   asset_report_token:   The asset report token for the
                                             asset report you want to remove.
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
 
         return self.client.post('/asset_report/remove', {
             'asset_report_token': asset_report_token,
-        })
+        }, session=session)
 
 
 class AuditCopy(API):
@@ -126,7 +144,8 @@ class AuditCopy(API):
 
     def create(self,
                asset_report_token,
-               auditor_id):
+               auditor_id,
+               session=None):
         '''
         Creates an audit copy.
 
@@ -135,37 +154,45 @@ class AuditCopy(API):
         :param  str   auditor_id:           The ID of the third party with
                                             which you want to share the asset
                                             report.
+        :param  object  session:            A requests.Session instance to use for
+                                            making HTTP requests. Optional.
 
         '''
 
         return self.client.post('/asset_report/audit_copy/create', {
             'asset_report_token': asset_report_token,
             'auditor_id': auditor_id,
-        })
+        }, session=session)
 
     def get(self,
-            audit_copy_token):
+            audit_copy_token,
+            session=None):
         '''
         Retrieves an audit copy.
 
         :param  str   audit_copy_token:     The audit copy token for the audit
                                             copy you want to retrieve.
+        :param  object  session:            A requests.Session instance to use for
+                                            making HTTP requests. Optional.
         '''
 
         return self.client.post('/asset_report/audit_copy/get', {
             'audit_copy_token': audit_copy_token,
-        })
+        }, session=session)
 
     def remove(self,
-               audit_copy_token):
+               audit_copy_token,
+               session=None):
         '''
         Removes an audit copy.
 
         :param  str   audit_copy_token:     The audit copy token for the
                                             audit copy you want to remove.
+        :param  object  session:            A requests.Session instance to use for
+                                            making HTTP requests. Optional.
 
         '''
 
         return self.client.post('/asset_report/audit_copy/remove', {
             'audit_copy_token': audit_copy_token,
-        })
+        }, session=session)

--- a/plaid/api/auth.py
+++ b/plaid/api/auth.py
@@ -7,7 +7,8 @@ class Auth(API):
     def get(self,
             access_token,
             _options=None,
-            account_ids=None):
+            account_ids=None,
+            session=None):
         '''
         Retrieve account and routing numbers for checking and savings accounts.
         (`HTTP docs <https://plaid.com/docs/api/#auth>`__)
@@ -15,6 +16,8 @@ class Auth(API):
         :param  str     access_token:
         :param  [str]   account_ids:    A list of account_ids to retrieve for
                                         the item. Optional.
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
         options = _options or {}
         if account_ids is not None:
@@ -23,4 +26,4 @@ class Auth(API):
         return self.client.post('/auth/get', {
             'access_token': access_token,
             'options': options,
-        })
+        }, session=session)

--- a/plaid/api/categories.py
+++ b/plaid/api/categories.py
@@ -7,6 +7,11 @@ class Categories(API):
     (`HTTP docs <https://plaid.com/docs/api/#categories>`__)
     '''
 
-    def get(self):
-        '''Fetch all plaid categories.'''
-        return self.client.post_public('/categories/get', {})
+    def get(self, session=None):
+        '''
+        Fetch all plaid categories.
+
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
+        '''
+        return self.client.post_public('/categories/get', {}, session=session)

--- a/plaid/api/credit_details.py
+++ b/plaid/api/credit_details.py
@@ -7,12 +7,16 @@ class CreditDetails(API):
     (`HTTP docs <https://plaid.com/docs/api/#credit-details>`__)
     '''
 
-    def get(self, access_token):
+    def get(self,
+            access_token,
+            session=None):
         '''
         Retrieve credit details associated with an item.
 
         :param  str     access_token:
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
         return self.client.post('/credit_details/get', {
             'access_token': access_token,
-        })
+        }, session=session)

--- a/plaid/api/holdings.py
+++ b/plaid/api/holdings.py
@@ -8,12 +8,15 @@ class Holdings(API):
     '''
 
     def get(self,
-            access_token):
+            access_token,
+            session=None):
         '''
         Retrieve investment holdings information about an item.
 
         :param  str     access_token:
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
         return self.client.post('/investments/holdings/get', {
             'access_token': access_token,
-        })
+        }, session=session)

--- a/plaid/api/identity.py
+++ b/plaid/api/identity.py
@@ -8,12 +8,15 @@ class Identity(API):
     '''
 
     def get(self,
-            access_token):
+            access_token,
+            session=None):
         '''
         Retrieve information about an item.
 
         :param  str     access_token:
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
         return self.client.post('/identity/get', {
             'access_token': access_token,
-        })
+        }, session=session)

--- a/plaid/api/income.py
+++ b/plaid/api/income.py
@@ -7,13 +7,15 @@ class Income(API):
     (`HTTP docs <https://plaid.com/docs/api/#income>`__)
     '''
 
-    def get(self, access_token):
+    def get(self, access_token, session=None):
         '''
         Retrieve income data associated with an item.
         Adds the income product to the item if it does not already have it.
 
         :param str access_token:
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
         return self.client.post('/income/get', {
             'access_token': access_token,
-        })
+        }, session=session)

--- a/plaid/api/institutions.py
+++ b/plaid/api/institutions.py
@@ -7,12 +7,14 @@ class Institutions(API):
     (`HTTP docs <https://plaid.com/docs/api/#institutions>`__)
     '''
 
-    def get(self, count, offset=0, _options=None):
+    def get(self, count, offset=0, _options=None, session=None):
         '''
         Fetch all Plaid institutions, using /institutions/all.
 
         :param  int     count:      Number of institutions to fetch.
         :param  int     offset:     Number of institutions to skip.
+        :param  object  session:    A requests.Session instance to use for
+                                    making HTTP requests. Optional.
         '''
 
         options = _options or {}
@@ -21,28 +23,32 @@ class Institutions(API):
             'count': count,
             'offset': offset,
             'options': options,
-        })
+        }, session=session)
 
-    def get_by_id(self, institution_id, _options=None):
+    def get_by_id(self, institution_id, _options=None, session=None):
         '''
         Fetch a single institution by id.
 
         :param  str     institution_id:
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
         options = _options or {}
 
         return self.client.post('/institutions/get_by_id', {
             'institution_id': institution_id,
             'options': options,
-        })
+        }, session=session)
 
-    def search(self, query, _options=None, products=None):
+    def search(self, query, _options=None, products=None, session=None):
         '''
         Search all institutions by name.
 
         :param  str      query:     Query against the full list of
                                     institutions.
         :param  [str]    products:  Filter FIs by available products. Optional.
+        :param  object   session:   A requests.Session instance to use for
+                                    making HTTP requests. Optional.
         '''
         options = _options or {}
 
@@ -50,4 +56,4 @@ class Institutions(API):
             'query': query,
             'products': products,
             'options': options,
-        })
+        }, session=session)

--- a/plaid/api/investment_transactions.py
+++ b/plaid/api/investment_transactions.py
@@ -12,7 +12,7 @@ class InvestmentTransactions(API):
             account_ids=None,
             count=None,
             offset=None,
-            ):
+            session=None):
         '''
         Return accounts and investment transactions for an item.
         (`HTTP docs <https://plaid.com/docs/api/#investment-transactions>`__)
@@ -30,6 +30,8 @@ class InvestmentTransactions(API):
                                         Optional.
         :param  int     offset:         The number of transactions to skip from
                                         the beginning of the fetch. Optional.
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
 
         All date should be formatted as ``YYYY-MM-DD``.
         '''
@@ -47,4 +49,4 @@ class InvestmentTransactions(API):
             'start_date': start_date,
             'end_date': end_date,
             'options': options,
-        })
+        }, session=session)

--- a/plaid/api/item.py
+++ b/plaid/api/item.py
@@ -3,73 +3,83 @@ from plaid.api.api import API
 
 class AddToken(API):
     '''Endpoints for managing item add tokens.'''
-    def create(self, user):
+    def create(self, user, session=None):
         '''
         Create a Link item add token.
 
-        :param  dict user:  An optional dictionary with additional user data.
+        :param  dict    user:       An optional dictionary with additional user data.
+        :param  object  session:    A requests.Session instance to use for
+                                    making HTTP requests. Optional.
         '''
         return self.client.post('/item/add_token/create', {
             'user': user,
-        })
+        }, session=session)
 
 
 class PublicToken(API):
     '''Endpoints for translating between public tokens and access tokens.'''
 
-    def exchange(self, public_token):
+    def exchange(self, public_token, session=None):
         '''
         Exchange a Link public_token for an API access_token.
         (`HTTP docs <https://plaid.com/docs/api/#exchange-token-flow>`__)
 
         :param  str     public_token:
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
         return self.client.post('/item/public_token/exchange', {
             'public_token': public_token,
-        })
+        }, session=session)
 
-    def create(self, access_token):
+    def create(self, access_token, session=None):
         '''
         Create a Link public_token for an API access_token.
         (`HTTP docs <https://plaid.com/docs/api/#create-public-token>`__)
 
         :param  str     access_token:
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
         return self.client.post('/item/public_token/create', {
             'access_token': access_token,
-        })
+        }, session=session)
 
 
 class AccessToken(API):
     '''Access token endpoints.'''
 
-    def invalidate(self, access_token):
+    def invalidate(self, access_token, session=None):
         '''
         Rotate the access token for an item.
         (`HTTP docs <https://plaid.com/docs/api/#rotate-access-token>`__)
 
         :param  str     access_token:
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
         return self.client.post('/item/access_token/invalidate', {
             'access_token': access_token,
-        })
+        }, session=session)
 
 
 class Webhook(API):
     '''Webhook endpoints.'''
 
-    def update(self, access_token, webhook):
+    def update(self, access_token, webhook, session=None):
         '''
         Update the webhook for an Item.
         (`HTTP docs <https://plaid.com/docs/api/#update-webhook>`__)
 
         :param  str     access_token:
         :param  str     webhook: The URL of the webhook to associate.
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
         return self.client.post('./item/webhook/update', {
             'access_token': access_token,
             'webhook': webhook,
-        })
+        }, session=session)
 
 
 class Item(API):
@@ -94,18 +104,20 @@ class Item(API):
         self.add_token = AddToken(client)
         self.webhook = Webhook(client)
 
-    def get(self, access_token):
+    def get(self, access_token, session=None):
         '''
         Get information about the status of an item.
         (`HTTP docs <https://plaid.com/docs/api/#get-item>`__)
 
         :param  str     access_token:
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
         return self.client.post('/item/get', {
             'access_token': access_token,
-        })
+        }, session=session)
 
-    def remove(self, access_token):
+    def remove(self, access_token, session=None):
         '''
         Remove an item.
         (`HTTP docs <https://plaid.com/docs/api/#remove-an-item>`__)
@@ -113,12 +125,14 @@ class Item(API):
         This also deactivates the access_token.
 
         :param  str     access_token:
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
         return self.client.post('/item/remove', {
             'access_token': access_token,
-        })
+        }, session=session)
 
-    def import_item(self, products, user_auth, _options):
+    def import_item(self, products, user_auth, _options, session=None):
         '''
         Imports an item.
         (`HTTP docs coming soon`__)
@@ -128,6 +142,8 @@ class Item(API):
         :param  dict    user_auth:          User authentication fields for the
                                             item.
         :param  dict    options:            Additional options.
+        :param  object  session:            A requests.Session instance to use for
+                                            making HTTP requests. Optional.
         '''
         options = _options or {}
 
@@ -135,4 +151,4 @@ class Item(API):
             'products': products,
             'user_auth': user_auth,
             'options': options,
-        })
+        }, session=session)

--- a/plaid/api/liabilities.py
+++ b/plaid/api/liabilities.py
@@ -10,13 +10,16 @@ class Liabilities(API):
     def get(self,
             access_token,
             _options=None,
-            account_ids=None):
+            account_ids=None,
+            session=None):
         '''
         Retrieve liabilities information about an item.
 
         :param  str     access_token:
         :param  [str]   account_ids:    A list of account_ids to retrieve for
                                         the item. Optional
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
         options = _options or {}
         if account_ids is not None:
@@ -25,4 +28,4 @@ class Liabilities(API):
         return self.client.post('/liabilities/get', {
             'access_token': access_token,
             'options': options,
-        })
+        }, session=session)

--- a/plaid/api/processor.py
+++ b/plaid/api/processor.py
@@ -4,13 +4,15 @@ from plaid.api.api import API
 class Processor(API):
     '''Endpoints for creating processor tokens.'''
 
-    def tokenCreate(self, access_token, account_id, processor):
+    def tokenCreate(self, access_token, account_id, processor, session=None):
         '''
         Create a processor token for a given processor and account ID
 
         :param  str     access_token:
         :param  str     account_id:
         :param  str     processor:
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
         endpoint = 'processor/token/create'
         options = {
@@ -26,32 +28,34 @@ class Processor(API):
             endpoint = '/processor/apex/processor_token/create'
             del options['processor']
 
-        return self.client.post(endpoint, options)
+        return self.client.post(endpoint, options, session=session)
 
-    def stripeBankAccountTokenCreate(self, access_token, account_id):
+    def stripeBankAccountTokenCreate(self, access_token, account_id, session=None):
         '''
         Create a Stripe bank_account token for a given account ID
         (`HTTP docs <https://plaid.com/docs/link/stripe>`__)
 
         :param  str     access_token:
         :param  str     account_id:
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
-        return self.client.post('/processor/stripe/bank_account_token/create',
-                                {
-                                    'access_token': access_token,
-                                    'account_id': account_id,
-                                })
+        return self.client.post('/processor/stripe/bank_account_token/create', {
+            'access_token': access_token,
+            'account_id': account_id,
+        }, session=session)
 
-    def dwollaBankAccountTokenCreate(self, access_token, account_id):
+    def dwollaBankAccountTokenCreate(self, access_token, account_id, session=None):
         '''
         Create a Dwolla processor token for a given account ID
         (`HTTP docs <https://plaid.com/docs/link/dwolla>`__)
 
         :param  str     access_token:
         :param  str     account_id:
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
-        return self.client.post('/processor/dwolla/processor_token/create',
-                                {
-                                    'access_token': access_token,
-                                    'account_id': account_id,
-                                })
+        return self.client.post('/processor/dwolla/processor_token/create', {
+            'access_token': access_token,
+            'account_id': account_id,
+        }, session=session)

--- a/plaid/api/sandbox.py
+++ b/plaid/api/sandbox.py
@@ -4,30 +4,35 @@ from plaid.api.api import API
 class Item(API):
     '''Sandbox item endpoints.'''
 
-    def reset_login(self, access_token):
+    def reset_login(self, access_token, session=None):
         '''
         Put an item into an ITEM_LOGIN_REQUIRED error state.
 
         :param  str     access_token:
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
         return self.client.post('/sandbox/item/reset_login', {
             'access_token': access_token,
-        })
+        }, session=session)
 
-    def fire_webhook(self, access_token, webhook_code):
+    def fire_webhook(self, access_token, webhook_code, session=None):
         '''
         Fire a webhook for an item
 
         :param  str     access_token:
         :param  str     webhook_code:
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
         return self.client.post('/sandbox/item/fire_webhook', {
             'access_token': access_token,
             'webhook_code': webhook_code,
-        })
+        }, session=session)
 
     def set_verification_status(self, access_token, account_id,
-                                verification_status):
+                                verification_status,
+                                session=None):
         '''
         Set verification status for an item created via the
         automated microdeposits flow
@@ -35,12 +40,14 @@ class Item(API):
         :param  str     access_token:
         :param  str     account_id:
         :param  str     verification_status:
+        :param  object  session:            A requests.Session instance to use for
+                                            making HTTP requests. Optional.
         '''
         return self.client.post('/sandbox/item/set_verification_status', {
             'access_token': access_token,
             'account_id': account_id,
             'verification_status': verification_status,
-        })
+        }, session=session)
 
 
 class PublicToken(API):
@@ -53,7 +60,7 @@ class PublicToken(API):
                webhook=None,
                transactions__start_date=None,
                transactions__end_date=None,
-               ):
+               session=None):
         '''
         Generate a public token for sandbox testing.
 
@@ -62,6 +69,9 @@ class PublicToken(API):
         :param  [str]   initial_products:
 
         :param  str     webhook:
+
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
         options = _options or {}
 
@@ -81,7 +91,7 @@ class PublicToken(API):
             'institution_id': institution_id,
             'initial_products': initial_products,
             'options': options,
-        })
+        }, session=session)
 
 
 class Sandbox(API):

--- a/plaid/api/transactions.py
+++ b/plaid/api/transactions.py
@@ -12,7 +12,7 @@ class Transactions(API):
             account_ids=None,
             count=None,
             offset=None,
-            ):
+            session=None):
         '''
         Return accounts and transactions for an item.
         (`HTTP docs <https://plaid.com/docs/api/#transactions>`__)
@@ -30,6 +30,8 @@ class Transactions(API):
                                         Optional.
         :param  int     offset:         The number of transactions to skip from
                                         the beginning of the fetch. Optional.
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
 
         All date should be formatted as ``YYYY-MM-DD``.
         '''
@@ -47,10 +49,11 @@ class Transactions(API):
             'start_date': start_date,
             'end_date': end_date,
             'options': options,
-        })
+        }, session=session)
 
     def refresh(self,
                 access_token,
+                session=None,
                 ):
         '''
         Request on-demand refresh of transactions and balances for an Item
@@ -62,7 +65,9 @@ class Transactions(API):
         call /transactions/get.
 
         :param  str     access_token:
+        :param  object  session:        A requests.Session instance to use for
+                                        making HTTP requests. Optional.
         '''
         return self.client.post('/transactions/refresh', {
             'access_token': access_token,
-        })
+        }, session=session)

--- a/plaid/client.py
+++ b/plaid/client.py
@@ -93,20 +93,20 @@ class Client(object):
         self.Transactions = Transactions(self)
         self.Webhooks = Webhooks(self)
 
-    def post(self, path, data, is_json=True):
+    def post(self, path, data, is_json=True, session=None):
         '''Make a post request with client_id and secret key.'''
         post_data = {
             'client_id': self.client_id,
             'secret': self.secret,
         }
         post_data.update(data)
-        return self._post(path, post_data, is_json)
+        return self._post(path, post_data, is_json, session=session)
 
-    def post_public(self, path, data, is_json=True):
+    def post_public(self, path, data, is_json=True, session=None):
         '''Make a post request requiring no auth.'''
-        return self._post(path, data, is_json)
+        return self._post(path, data, is_json, session=session)
 
-    def _post(self, path, data, is_json):
+    def _post(self, path, data, is_json, session=None):
         headers = {}
         if self.api_version is not None:
             headers['Plaid-Version'] = self.api_version
@@ -118,4 +118,5 @@ class Client(object):
             timeout=self.timeout,
             is_json=is_json,
             headers=headers,
+            session=session,
         )

--- a/plaid/internal/requester.py
+++ b/plaid/internal/requester.py
@@ -22,11 +22,12 @@ def _requests_http_request(
         method,
         data,
         headers,
-        timeout=DEFAULT_TIMEOUT):
+        timeout=DEFAULT_TIMEOUT,
+        session=None):
     normalized_method = method.lower()
     headers.update({'User-Agent': 'Plaid Python v{}'.format(__version__)})
     if normalized_method in ALLOWED_METHODS:
-        return getattr(requests, normalized_method)(
+        return getattr(session or requests, normalized_method)(
             url,
             json=data,
             headers=headers,
@@ -44,13 +45,15 @@ def _http_request(
         data=None,
         headers=None,
         timeout=DEFAULT_TIMEOUT,
-        is_json=True):
+        is_json=True,
+        session=None):
     response = _requests_http_request(
         url,
         method,
         data or {},
         headers or {},
-        timeout)
+        timeout,
+        session=session)
 
     if is_json or response.headers['Content-Type'] == 'application/json':
         try:


### PR DESCRIPTION
This has been updated to be consistent with current state of plaid-python.

Per previous comments, if maintainers want this moved to "options" that's fine (and I will update). However, the current API method signatures are varied and they do not all support "options".

Original PR: https://github.com/plaid/plaid-python/pull/182