### PR TITLE
Update Dockerfile to Multi-Stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Note: This image is also built in CircleCI, so limit references to internal repositories.
-FROM python:3.7
+### Build stage
+FROM python:3.7 AS builder
 
 # Create app directory
 WORKDIR /usr/src/app
@@ -11,5 +12,10 @@ COPY . /usr/src/app
 # https://discuss.circleci.com/t/python-tox-doesnt-build-anymore/35059
 RUN pip install tox==3.15.0
 RUN pip install -r requirements.txt
+
+### Runtime stage
+FROM python:3.7
+COPY --from=builder /usr/src/app /usr/src/app
+WORKDIR /usr/src/app
 
 CMD ["make", "test"]


### PR DESCRIPTION
Hi,

Thanks for maintaining plaid-python. I represent a research group investigating [multi-stage builds](https://docs.docker.com/build/building/multi-stage/). We recently refactored your Dockerfile to a multi-stage Dockerfile and found that it brings the following benefits: 

✅ Reduced final image size (from 1281MB to 972MB)  
✅ Minimized image vulnerabilities (verified via [Trivy](https://github.com/aquasecurity/trivy), from 7 to 3)  

We hope this minor improvement to the Dockerfile will be useful to you :)

Thanks,