### PR TITLE
Remove `nulltype`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 ##### Dependencies
-nulltype
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.25.3

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ url = 'https://github.com/plaid/plaid-python'
 REQUIRES = [
   "urllib3 >= 1.25.3",
   "python-dateutil",
-  "nulltype",
 ]
 
 setup(


### PR DESCRIPTION
AFAICT, there are no references to this in the codebase, at all. It thus ends up in all downstream consumers' dependency trees, and I'm wondering if we can prune that tree a bit, if this is truly unused.