### PR TITLE
Update README to specify Plaid API version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ This library only supports `python3`!
 $ pip3 install plaid-python
 ```
 
+
+
+
 ## Versioning
 
 This release only supports the latest Plaid API version, `2020-09-14`.


### PR DESCRIPTION
Clarified that the release supports only the latest Plaid API version.